### PR TITLE
Add 'import torch.nn.functional' before F is first used in Layers subsection

### DIFF
--- a/Part2.ipynb
+++ b/Part2.ipynb
@@ -8,8 +8,7 @@
     "\n",
     "This tutorial is designed to provide a short introduction to deep learning with PyTorch.\n",
     "\n",
-    "You can start studying this tutorial as you work through unit 3 of the course.",
-    "\n",
+    "You can start studying this tutorial as you work through unit 3 of the course.\n",
     "For more resources, check out [the PyTorch tutorials](https://pytorch.org/tutorials/)! There are many more in-depth examples available there.\n"
    ]
   },
@@ -1037,6 +1036,8 @@
    },
    "outputs": [],
    "source": [
+    "import torch.nn.functional as F\n",
+    "\n",
     "# Make our own model!\n",
     "\n",
     "class Net(nn.Module):\n",
@@ -1553,7 +1554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
`F` is used in this cell before it has been defined.  This can cause some confusion on first read-through (and presumably the code wouldn't be able to execute).

Thanks for putting these resources together!