### PR TITLE
Create environment.yml for mybinder.org

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: myenvironment
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - numpy
+  - pip
+  - pip:
+    - torch
+    - matplotlib
+    - sklearn
+    - pandas
+    - tqdm
+    - torchvision
+    


### PR DESCRIPTION
Hi there, I created a environmant.yml for lunching the notebooks on mybinder.org with all the modules used in the two files.. I think it would be much more interesting for the students to have directly a live notebook.

I did test the two notebooks, they run, with the only problem at the end of the second tutorial, as the MINST db can not be downloaded from internet (I am pretty sure it is a security constrain in mybinder), it should be put in the github repository instead.

Also I didn't add it, but I think it would be nice to have  a link on top of the static notebooks to their live version.

Note that binder build the docker image at each commit, so the first time you make a commit the live version is much slower to start. the next time an user goes it will use a cached image instead.